### PR TITLE
Fix new member creation in ProcessProposal handler

### DIFF
--- a/packages/moloch-subgraph/src/mapping.ts
+++ b/packages/moloch-subgraph/src/mapping.ts
@@ -119,15 +119,14 @@ export function handleProcessProposal(event: ProcessProposal): void {
       newMember.isActive = true
       newMember.tokenTribute = event.params.tokenTribute
       newMember.didRagequit = false
-      member.votes = new Array<string>()
-      member.submissions = new Array<string>()
+      newMember.votes = new Array<string>()
+      newMember.submissions = new Array<string>()
       newMember.save()
     } else {
       member.shares = member.shares.plus(event.params.sharesRequested)
       member.tokenTribute = member.tokenTribute.plus(event.params.tokenTribute)
       member.save()
     }
-    
   }
 }
 

--- a/packages/moloch-subgraph/subgraph.yaml
+++ b/packages/moloch-subgraph/subgraph.yaml
@@ -1,6 +1,6 @@
 specVersion: 0.0.1
 description: Moloch subgraph
-repository: https://github.com/moloch/subgraph
+repository: https://github.com/MolochVentures/moloch-monorepo/
 schema:
   file: ./schema.graphql
 dataSources:


### PR DESCRIPTION
The wrong variable was used to initialize the votes and submissions
of the new member, causing later SubmitVote handlers to fail because
the member wouldn't have any votes.

Tested locally. This should fix the Moloch subgraph on https://thegraph.com/explorer/subgraph/jamesyoung/moloch.