### PR TITLE
Fix header error

### DIFF
--- a/packages/moloch-frontend/src/components/Header.js
+++ b/packages/moloch-frontend/src/components/Header.js
@@ -142,7 +142,14 @@ export default class Header extends Component {
   };
 
   async componentDidMount() {
-    const moloch = await getMoloch();
+    let moloch;
+    try {
+      moloch = await getMoloch();
+    } catch (err) {
+        // NOTE: When the header is loaded for the first time, loading Moloch
+        // will fail as no values have been set in local storage. The user can
+        // set them on the home screen
+    }
     this.setState({ moloch });
   }
 


### PR DESCRIPTION
When a user first visits the moloch frontend, the haven't had a chance to set `localStorage.getItem("loginType")`. The app crashes, however, if `const moloch` isn't loadable in Header.js.

I fixed this by wrapping `getMoloch` in a try-catch. Not sure if this is particularly helpful :/