### PR TITLE
Fix the version of smart contracts from  0.5.3 to  0.5.8

### DIFF
--- a/packages/contracts/contracts/GuildBank.sol
+++ b/packages/contracts/contracts/GuildBank.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.3;
+pragma solidity 0.5.8;
 
 import "./oz/Ownable.sol";
 import "./oz/ERC20.sol";

--- a/packages/contracts/contracts/Migrations.sol
+++ b/packages/contracts/contracts/Migrations.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.3;
+pragma solidity 0.5.8;
 
 contract Migrations {
     address public owner;

--- a/packages/contracts/contracts/Moloch.sol
+++ b/packages/contracts/contracts/Moloch.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.3;
+pragma solidity 0.5.8;
 
 import "./oz/SafeMath.sol";
 import "./oz/ERC20.sol";

--- a/packages/contracts/truffle.js
+++ b/packages/contracts/truffle.js
@@ -4,7 +4,7 @@ const privateKeys = ["659c..."]; // insert full PK here
 module.exports = {
   networks: {
     development: {
-      host: 'localhost',
+      host: '0.0.0.0',
       port: 8545,
       gas: 4700000,
       network_id: '*' // Match any network id


### PR DESCRIPTION
1.If now you try to install truffle your default compiler will be the 0.5.8 . So I think it would be easier to have the smart contracts updated.
2. Change the host from localhost to 0.0.0.0 because truffle could not connect to the ganache.