### PR TITLE
Subgraph fixes for the upcoming Graph Node release

### DIFF
--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -69,6 +69,6 @@ type PoolMember @entity {
 
 type PoolMeta @entity {
   id: ID!
-  currentPoolIndex: BigInt!
+  currentPoolIndex: BigInt
   totalPoolShares: BigInt!
 }

--- a/packages/subgraph/schema.graphql
+++ b/packages/subgraph/schema.graphql
@@ -1,7 +1,7 @@
 type Vote @entity {
   id: ID!
-  timestamp:String!
-  proposalIndex:BigInt!
+  timestamp: String!
+  proposalIndex: BigInt!
   delegateKey: Bytes!
   memberAddress: Bytes!
   uintVote: Int!
@@ -11,7 +11,7 @@ type Vote @entity {
 
 type Proposal @entity {
   id: ID!
-  timestamp:String!
+  timestamp: String!
   proposalIndex: BigInt!
   startingPeriod: BigInt!
   delegateKey: Bytes!
@@ -20,7 +20,7 @@ type Proposal @entity {
   applicant: Applicant!
   applicantAddress: Bytes!
   tokenTribute: BigInt!
-  sharesRequested:BigInt!
+  sharesRequested: BigInt!
   yesVotes: BigInt!
   noVotes: BigInt!
   yesShares: BigInt!
@@ -35,17 +35,17 @@ type Proposal @entity {
 
 type Applicant @entity {
   id: ID!
-  timestamp:String!
+  timestamp: String!
   proposalIndex: BigInt!
   delegateKey: Bytes!
   member: Member!
   memberAddress: Bytes!
   applicantAddress: Bytes!
   tokenTribute: BigInt!
-  sharesRequested:BigInt!
+  sharesRequested: BigInt!
   didPass: Boolean!
   aborted: Boolean!
-  votes: [Vote!]! 
+  votes: [Vote!]!
   proposal: Proposal!
 }
 

--- a/packages/subgraph/src/mapping.ts
+++ b/packages/subgraph/src/mapping.ts
@@ -30,6 +30,7 @@ export function handleSummonComplete(event: SummonComplete): void {
   member.didRagequit = false;
   member.votes = new Array<string>();
   member.submissions = new Array<string>();
+  member.highestIndexYesVote = BigInt.fromI32(0);
   member.save();
 }
 
@@ -70,6 +71,7 @@ export function handleSubmitProposal(event: SubmitProposal): void {
   proposal.noVotes = BigInt.fromI32(0);
   proposal.yesShares = BigInt.fromI32(0);
   proposal.noShares = BigInt.fromI32(0);
+  proposal.maxTotalSharesAtYesVote = BigInt.fromI32(0);
   proposal.processed = false;
   proposal.didPass = false;
   proposal.aborted = false;
@@ -146,7 +148,7 @@ export function handleSubmitVote(event: SubmitVote): void {
 }
 
 export function handleProcessProposal(event: ProcessProposal): void {
-  let proposal = Proposal.load(event.params.proposalIndex.toString());
+  let proposal = new Proposal(event.params.proposalIndex.toString());
   proposal.applicant = event.params.applicant.toHex();
   proposal.memberAddress = event.params.memberAddress;
   proposal.tokenTribute = event.params.tokenTribute;
@@ -170,6 +172,7 @@ export function handleProcessProposal(event: ProcessProposal): void {
       newMember.didRagequit = false;
       newMember.votes = new Array<string>();
       newMember.submissions = new Array<string>();
+      newMember.highestIndexYesVote = BigInt.fromI32(0);
       newMember.save();
     } else {
       member.shares = member.shares.plus(event.params.sharesRequested);

--- a/packages/subgraph/subgraph.yaml
+++ b/packages/subgraph/subgraph.yaml
@@ -1,4 +1,4 @@
-specVersion: 0.0.1
+specVersion: 0.0.2
 description: A community DAO focused on funding Ethereum development, in the name of Moloch the God of Coordination Failure.
 repository: https://github.com/MolochVentures/moloch-monorepo/
 schema:


### PR DESCRIPTION
The upcoming version of graph-node will enforce stricter rules on entity fields, requiring (among other things) non-nullable fields on entities to always be set.

This PR addresses this by:

- making the `currentPoolIndex` field of the `PoolMeta` entity optional (not sure this is the right thing to do though),
- Initializing the `highestIndexYesVote` field of `Member` to `0`.
- Initializing the `maxTotalSharesAtYesVote` field of `Proposal` to `0`.